### PR TITLE
Export utility method to check for decoration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export {Binder, SyncFactory, AsyncFactory, BindAs} from './binder.js';
 export {Container} from './container.js';
 export {Inject, Injectable, Optional, PostConstruct, Release} from './decorators.js';
 export {ClassConstructor, InjectableId, InjectionToken, Injector} from './injector.js';
+export {hasDecoration} from './utils.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/explicit-module-boundary-types */
-import {RELEASE_METADATA_KEY} from './constants.js';
+import {RELEASE_METADATA_KEY, INJECTABLE_METADATA_KEY} from './constants.js';
+import type {ClassConstructor} from './injector.js';
 
 /**
  * Returns true if the specified object looks like a JavaScript Error object.
@@ -44,4 +45,14 @@ export function InvokeReleaseMethod<T = unknown>(obj: T): boolean {
 	}
 	/* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 	return false;
+}
+
+/**
+ * A simple utility method to determine if the specified class has been tagged as @Injectable already.
+ */
+export function hasDecoration(target: ClassConstructor<unknown>): boolean {
+	if (typeof target !== 'object' || target === null) {
+		throw new Error('target not an object:' + target.toString());
+	}
+	return Reflect.hasOwnMetadata(INJECTABLE_METADATA_KEY, target)
 }


### PR DESCRIPTION
Found that in order to more gradually transition our existing code's service locator to use DI, it's helpful to be able to check if a class has already been annotated. 

Open to suggestions on the code placement and strategy for export. (e.g. Should it be part of a `Utils` object, even if it's the only function there for now?) I didn't want to assume we could just `export * as Utils from './utils.js';` but that would work, too :) 